### PR TITLE
Add major instead of minor in PlaceSellOrder

### DIFF
--- a/src/bitso/private/Trade.ts
+++ b/src/bitso/private/Trade.ts
@@ -99,7 +99,7 @@ export class TradeAPI extends HttpClient {
       book: currency,
       side: 'sell',
       type: 'market',
-      minor: quantity,
+      major: quantity,
     };
     return await this.placeOrder(request);
   }


### PR DESCRIPTION
# Fixes #1 
## PR Description
The following PR solves the "minor" parameter in PlaceSellOrder and replaces it for Major.
The logic behind this:

When you buy you are acquiring the "MAJOR" from the currency asset using the MINOR. (BTC/MXN = MAJOR/MINOR) so... 1000 units of MINOR gives you a X from MAJOR. When you make the inverse operation (SELLING) X from MAJOR are being sold for X Minor. So you're creating an operation USING the current owned currency. (MXN or BTC in this example).

## Testing
You could place a sell order using your current currency owned in PlaceSellOrder as a parameter.